### PR TITLE
Fix IPv4 parser

### DIFF
--- a/src/HaskellWorks/Data/Network/Ip/Internal.hs
+++ b/src/HaskellWorks/Data/Network/Ip/Internal.hs
@@ -27,9 +27,11 @@ infixl 2 #<*>#
 octet :: AP.Parser Word8
 octet = ((d12 #<*># d5 ) #<*># d05)
   <|>   ((d12 #<*># d04) #<*># d09)
+  <|>   ((d1  #<*># d09) #<*># d09)
   <|>   ( d19 #<*># d09)
   <|>   d09
   where d5  = fromIntegral . (+ (-48)) . ord <$> AP.satisfy (== '5')
+        d1  = fromIntegral . (+ (-48)) . ord <$> AP.satisfy (== '1')
         d04 = fromIntegral . (+ (-48)) . ord <$> AP.satisfy (\c -> c >= '0' && c <= '4')
         d05 = fromIntegral . (+ (-48)) . ord <$> AP.satisfy (\c -> c >= '0' && c <= '5')
         d09 = fromIntegral . (+ (-48)) . ord <$> AP.satisfy (\c -> c >= '0' && c <= '9')

--- a/test/HaskellWorks/Data/Network/IpSpec.hs
+++ b/test/HaskellWorks/Data/Network/IpSpec.hs
@@ -17,6 +17,11 @@ spec = describe "HaskellWorks.HUnit.IpSpec" $ do
       show (Ipv4Address 0x0000ff00) === "0.0.255.0"
       show (Ipv4Address 0x00ff0000) === "0.255.0.0"
       show (Ipv4Address 0xff000000) === "255.0.0.0"
+    it "should implement read" $ require $ property $ do
+      read "1.2.3.4"      === Ipv4Address 0x01020304
+      read "10.20.30.40"  === Ipv4Address 0x0a141e28
+      read "1.2.3.12"     === Ipv4Address 0x0102030c
+      read "1.2.3.160"    === Ipv4Address 0x010203a0
   describe "Ipv4Block" $ do
     it "should implement show" $ require $ property $ do
       show (Ipv4Block (Ipv4Address 0x000000ff) (Ipv4NetMask 32)) === "0.0.0.255/32"


### PR DESCRIPTION
Any IP with an octet value `100 >= x <= 199` was failing.