### PR TITLE
MAYH-10072 start/stop ipv4 address of Ipv4Block

### DIFF
--- a/src/HaskellWorks/Data/Network/Ip.hs
+++ b/src/HaskellWorks/Data/Network/Ip.hs
@@ -12,6 +12,8 @@ module HaskellWorks.Data.Network.Ip
   , textToMaybeIpv4Address
   , ipv4AddressToString
   , ipv4AddressToText
+  , startIpv4Address
+  , stopIpv4Address
   ) where
 
 import Control.Monad
@@ -45,6 +47,12 @@ splitBlock (Z.Ipv4Block (Z.Ipv4Address b) (Z.Ipv4NetMask m)) =
 
 blockSize :: Z.Ipv4Block -> Int
 blockSize (Z.Ipv4Block _ m) = 2 ^ bitPower m
+
+startIpv4Address :: Z.Ipv4Block -> Z.Ipv4Address
+startIpv4Address (Z.Ipv4Block base _) = base
+
+stopIpv4Address :: Z.Ipv4Block -> Z.Ipv4Address
+stopIpv4Address b@(Z.Ipv4Block (Z.Ipv4Address base) _) = Z.Ipv4Address (base + fromIntegral (blockSize b) - 1)
 
 textToMaybeIpv4Address :: T.Text -> Maybe Z.Ipv4Address
 textToMaybeIpv4Address t = join $ AP.maybeResult <$> AP.parseWith (return mempty) APT.ipv4Address t

--- a/test/HaskellWorks/Data/Network/IpSpec.hs
+++ b/test/HaskellWorks/Data/Network/IpSpec.hs
@@ -32,6 +32,16 @@ spec = describe "HaskellWorks.HUnit.IpSpec" $ do
       show (Ipv4Block (Ipv4Address 0x0000ff00) (Ipv4NetMask 16)) === "0.0.255.0/16"
       show (Ipv4Block (Ipv4Address 0x00ff0000) (Ipv4NetMask 16)) === "0.255.0.0/16"
       show (Ipv4Block (Ipv4Address 0xff000000) (Ipv4NetMask 16)) === "255.0.0.0/16"
+      show (startIpv4Address $ Ipv4Block (Ipv4Address 0xff000000) (Ipv4NetMask 8)) === "255.0.0.0"
+      show (stopIpv4Address $ Ipv4Block (Ipv4Address 0xff000000) (Ipv4NetMask 8)) === "255.255.255.255"
+      show (startIpv4Address $ Ipv4Block (Ipv4Address 0xff000000) (Ipv4NetMask 16)) === "255.0.0.0"
+      show (stopIpv4Address $ Ipv4Block (Ipv4Address 0xff000000) (Ipv4NetMask 16)) === "255.0.255.255"
+      show (startIpv4Address $ Ipv4Block (Ipv4Address 0xff000000) (Ipv4NetMask 24)) === "255.0.0.0"
+      show (stopIpv4Address $ Ipv4Block (Ipv4Address 0xff000000) (Ipv4NetMask 24)) === "255.0.0.255"
+      show (startIpv4Address $ Ipv4Block (Ipv4Address 0xff000000) (Ipv4NetMask 32)) === "255.0.0.0"
+      show (stopIpv4Address $ Ipv4Block (Ipv4Address 0xff000000) (Ipv4NetMask 32)) === "255.0.0.0"
+      show (startIpv4Address $ Ipv4Block (Ipv4Address 0xff000000) (Ipv4NetMask 21)) === "255.0.0.0"
+      show (stopIpv4Address $ Ipv4Block (Ipv4Address 0xff000000) (Ipv4NetMask 21)) === "255.0.7.255"
     it "should implement splitBlock" $ require $ property $ do
       splitBlock (Ipv4Block (Ipv4Address 0x00000000) (Ipv4NetMask 32)) === Nothing
       splitBlock (Ipv4Block (Ipv4Address 0x00000000) (Ipv4NetMask 31)) === Just (Ipv4Block (Ipv4Address 0x00000000) (Ipv4NetMask 32), Ipv4Block (Ipv4Address 0x00000001) (Ipv4NetMask 32))


### PR DESCRIPTION
```
HaskellWorks.Data.Network.Ip
  HaskellWorks.HUnit.IpSpec
    Ipv4Address
  ✓ <interactive> passed 100 tests.
      should implement show
  ✓ <interactive> passed 100 tests.
      should implement read
    Ipv4Block
  ✓ <interactive> passed 100 tests.
      should implement show
  ✓ <interactive> passed 100 tests.
      should implement splitBlock
  ✓ <interactive> passed 100 tests.
      should implement blockSize

Finished in 0.0752 seconds
5 examples, 0 failures

hw-ip-0.2.1.1: Test suite hw-ip-test passed
Completed 2 action(s).
```