### PR TITLE
MAYH-10151 a function to give us the octets of an IPv4 address

### DIFF
--- a/src/HaskellWorks/Data/Network/Ip.hs
+++ b/src/HaskellWorks/Data/Network/Ip.hs
@@ -12,6 +12,7 @@ module HaskellWorks.Data.Network.Ip
   , textToMaybeIpv4Address
   , ipv4AddressToString
   , ipv4AddressToText
+  , ipv4AddressToWords
   , firstIpv4Address
   , lastIpv4Address
   ) where
@@ -55,10 +56,18 @@ lastIpv4Address :: Z.Ipv4Block -> Z.Ipv4Address
 lastIpv4Address b@(Z.Ipv4Block (Z.Ipv4Address base) _) = Z.Ipv4Address (base + fromIntegral (blockSize b) - 1)
 
 textToMaybeIpv4Address :: T.Text -> Maybe Z.Ipv4Address
-textToMaybeIpv4Address t = join $ AP.maybeResult <$> AP.parseWith (return mempty) APT.ipv4Address t
+textToMaybeIpv4Address t = AP.maybeResult =<< AP.parseWith (return mempty) APT.ipv4Address t
 
 ipv4AddressToString :: Z.Ipv4Address -> String
 ipv4AddressToString = show
 
 ipv4AddressToText :: Z.Ipv4Address -> T.Text
 ipv4AddressToText = T.pack . ipv4AddressToString
+
+ipv4AddressToWords :: Z.Ipv4Address -> (Word8, Word8, Word8, Word8)
+ipv4AddressToWords (Z.Ipv4Address w) =
+  ( fromIntegral (w .>. 24) .&. 0xff
+  , fromIntegral (w .>. 16) .&. 0xff
+  , fromIntegral (w .>.  8) .&. 0xff
+  , fromIntegral (w         .&. 0xff)
+  )

--- a/test/HaskellWorks/Data/Network/IpSpec.hs
+++ b/test/HaskellWorks/Data/Network/IpSpec.hs
@@ -36,6 +36,9 @@ spec = describe "HaskellWorks.HUnit.IpSpec" $ do
       read "1.2.3.12"     === Ipv4Address 0x0102030c
       read "1.2.3.160"    === Ipv4Address 0x010203a0
 
+    it "should be possible to extract the octets" $ require $ property $ do
+      ipv4AddressToWords (Ipv4Address 0x01020304) === (1, 2, 3, 4)
+
   describe "Ipv4Block" $ do
     it "should implement show" $ require $ property $ do
       show (Ipv4Block (Ipv4Address 0x000000ff) (Ipv4NetMask 32)) === "0.0.0.255/32"


### PR DESCRIPTION
```
λ> ipv4AddressToWords $ read "255.2.3.4"
(255,2,3,4)
it :: (Word8, Word8, Word8, Word8)
```