### PR TITLE
Mayh 0000 collapse ipv4 addresses

### DIFF
--- a/hw-ip.cabal
+++ b/hw-ip.cabal
@@ -37,6 +37,7 @@ library
         base            >= 4            && < 4.13
       , appar           >= 0.1.7        && < 0.2
       , attoparsec      >= 0.13.2.2     && < 0.14
+      , containers
       , generic-lens    >= 0.5.1.0      && < 1.2
       , hw-bits         >= 0.7.0.2      && < 0.8
       , iproute         >= 1.7.3        && < 1.8

--- a/test/HaskellWorks/Data/Network/Ipv4Spec.hs
+++ b/test/HaskellWorks/Data/Network/Ipv4Spec.hs
@@ -2,13 +2,14 @@
 
 module HaskellWorks.Data.Network.Ipv4Spec (spec) where
 
-import HaskellWorks.Data.Network.Ip
 import HaskellWorks.Data.Network.Ip.Internal
+import HaskellWorks.Data.Network.Ip.Ipv4
 import HaskellWorks.Hspec.Hedgehog
 import Hedgehog
 import Test.Hspec
 
 import qualified Data.Attoparsec.Text              as AP
+import qualified Data.List                         as DL
 import qualified Data.Text                         as T
 import qualified HaskellWorks.Data.Network.Ip.Ipv4 as V4
 import qualified Hedgehog.Gen                      as G
@@ -86,3 +87,11 @@ spec = describe "HaskellWorks.HUnit.Ipv4Spec" $ do
       V4.canonicaliseIpBlock (V4.IpBlock (V4.IpAddress 0x01020304) (V4.IpNetMask 24)) === V4.IpBlock (V4.IpAddress 0x01020300) (V4.IpNetMask 24)
       V4.canonicaliseIpBlock (V4.IpBlock (V4.IpAddress 0x01020304) (V4.IpNetMask 16)) === V4.IpBlock (V4.IpAddress 0x01020000) (V4.IpNetMask 16)
       V4.canonicaliseIpBlock (V4.IpBlock (V4.IpAddress 0x01020304) (V4.IpNetMask  8)) === V4.IpBlock (V4.IpAddress 0x01000000) (V4.IpNetMask  8)
+
+    it "should collapse blocks" $ require $ property $ do
+      let ipblocks1 =    read <$> ["1.2.3.4/32", "4.3.2.1/32"]
+      collapseIpBlocks ipblocks1 === ipblocks1
+      let ipblocks2 = read <$> ["1.2.3.3/32", "1.2.3.0/32", "1.2.3.1/32", "1.2.3.2/32"]
+      collapseIpBlocks (DL.sort ipblocks2) === (read <$> ["1.2.3.0/30"])
+      let ipblocks3 = read <$> ["1.2.3.3/32", "1.2.3.0/32", "1.2.3.1/32", "1.2.3.2/32", "5.5.5.5/32"]
+      collapseIpBlocks (DL.sort ipblocks3) === (read <$> ["1.2.3.0/30", "5.5.5.5/32"])

--- a/test/HaskellWorks/Data/Network/Ipv4Spec.hs
+++ b/test/HaskellWorks/Data/Network/Ipv4Spec.hs
@@ -88,7 +88,7 @@ spec = describe "HaskellWorks.HUnit.Ipv4Spec" $ do
       V4.canonicaliseIpBlock (V4.IpBlock (V4.IpAddress 0x01020304) (V4.IpNetMask 16)) === V4.IpBlock (V4.IpAddress 0x01020000) (V4.IpNetMask 16)
       V4.canonicaliseIpBlock (V4.IpBlock (V4.IpAddress 0x01020304) (V4.IpNetMask  8)) === V4.IpBlock (V4.IpAddress 0x01000000) (V4.IpNetMask  8)
 
-    it "should collapse blocks" $ require $ property $ do
+    it "should collapse blocks" $ requireTest $ do
       let ipblocks1 =    read <$> ["1.2.3.4/32", "4.3.2.1/32"]
       collapseIpBlocks ipblocks1 === ipblocks1
       let ipblocks2 = read <$> ["1.2.3.3/32", "1.2.3.0/32", "1.2.3.1/32", "1.2.3.2/32"]


### PR DESCRIPTION
```
Finished in 0.0326 seconds
16 examples, 0 failures
Test suite hw-ip-test: PASS
Test suite logged to:
/Users/jwan/Start/atlas/haskell/hw-ip/dist-newstyle/build/x86_64-osx/ghc-8.4.3/hw-ip-1.0.0.0/t/hw-ip-test/test/hw-ip-1.0.0.0-hw-ip-test.log
1 of 1 test suites (1 of 1 test cases) passed.
Preprocessing test suite 'hw-ip-test' for hw-ip-1.0.0.0..
```