### PR TITLE
give IpAddresses a SafeEnum

### DIFF
--- a/src/HaskellWorks/Data/Network/Ip/Ipv4.hs
+++ b/src/HaskellWorks/Data/Network/Ip/Ipv4.hs
@@ -35,6 +35,7 @@ import Data.Word
 import GHC.Generics
 import HaskellWorks.Data.Bits.BitWise
 import HaskellWorks.Data.Network.Ip.Range
+import HaskellWorks.Data.Network.Ip.SafeEnum
 import HaskellWorks.Data.Network.Ip.Validity
 
 import qualified Data.Bits                             as B
@@ -45,7 +46,7 @@ import qualified Text.Appar.String                     as AP
 
 newtype IpAddress = IpAddress
   { word :: Word32
-  } deriving (Enum, Bounded, Eq, Ord, Generic)
+  } deriving (Enum, Bounded, Eq, Ord, Generic, SafeEnum)
 
 instance Show IpAddress where
   showsPrec _ = showsIpAddress

--- a/src/HaskellWorks/Data/Network/Ip/Ipv6.hs
+++ b/src/HaskellWorks/Data/Network/Ip/Ipv6.hs
@@ -45,7 +45,7 @@ import qualified HaskellWorks.Data.Network.Ip.Internal as I
 import qualified HaskellWorks.Data.Network.Ip.Ipv4     as V4
 import qualified HaskellWorks.Data.Network.Ip.Word128  as W
 
-newtype IpAddress = IpAddress W.Word128 deriving (Eq, Ord, Generic, SafeEnum)
+newtype IpAddress = IpAddress W.Word128 deriving (Enum, Eq, Ord, Generic, SafeEnum)
 
 instance Show IpAddress where
   showsPrec _ (IpAddress w) = shows (D.fromHostAddress6 w)

--- a/test/HaskellWorks/Data/Network/RangeSpec.hs
+++ b/test/HaskellWorks/Data/Network/RangeSpec.hs
@@ -8,6 +8,7 @@ import HaskellWorks.Hspec.Hedgehog
 import Hedgehog
 import Test.Hspec
 
+import qualified HaskellWorks.Data.Network.Ip.Ipv4  as V4
 import qualified HaskellWorks.Data.Network.Ip.Ipv6  as V6
 import qualified HaskellWorks.Data.Network.Ip.Range as R
 import qualified Text.Appar.String                  as AP
@@ -39,3 +40,9 @@ spec = describe "HaskellWorks.Data.Network.RangeSpec" $ do
     it "should parse dash-delimited ranges" $ requireTest $ do
       AP.runParser (AP.try (R.parseRange AP.alphaNum)) "a b"   === (Nothing               , "a b")
       AP.runParser (AP.try (R.parseRange AP.alphaNum)) "a - b" === (Just (R.Range 'a' 'b'), ""   )
+
+    it "should parse ip address ranges" $ requireTest $ do
+      let r1 = [ R.Range (V4.IpAddress 0x00000000) (V4.IpAddress 0x0001ffff)
+               , R.Range (V4.IpAddress 0x0000ffff) (V4.IpAddress 0x00ffffff)]
+      let r2 = [ R.Range (V4.IpAddress 0x00000000) (V4.IpAddress 0x00ffffff)]
+      R.mergeRanges r1 === r2


### PR DESCRIPTION
It's pretty hard to merge ranges without being able to call `mergeRanges` on IpAddress types